### PR TITLE
Safemail-landingpage-update-logo-copyright

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -177,7 +177,7 @@ import Modal from '../components/Modal.astro';
             <p>Safemail was created by product executives and cyber security experts coming from leading firms including
                 Accenture, Revolut, and PwC.</p>
             <br/>
-            <p class="text-center text-sm">&copy Sibylline Advisory Ltd, 2023</p>
+            <p class="text-center text-sm">&copy Sibylline Advisory Ltd, 2025</p>
         </div>
     </main>
     </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -159,7 +159,7 @@ import Modal from '../components/Modal.astro';
                 <a href="https://sibylline.xyz" target="_blank"><img alt="sibylline" src="sibylline-logo.png" height="80"></a>
                 <a href="https://www.riseworks.io" target="_blank"><img alt="rise" src="rise_logo.svg" height="80"></a>
                 <!-- <img alt="proelium" src="ProeliumLaw-Logo.png" height="80"> -->
-                <a href="https://shopthru.xyz" target="_blank"><img alt="shopthru" src="shopthru_logo.svg" height="80px"></a>
+                <!-- <a href="https://shopthru.xyz" target="_blank"><img alt="shopthru" src="shopthru_logo.svg" height="80px"></a> -->
                 <a href="https://joinharvest.xyz" target="_blank"><img alt="harvest" src="harvest_icon@88.png" height="80"></a>
                 <a href="https://www.simplicitygroup.xyz" target="_blank"><img alt="sg" src="sg_logo.jpeg" height="80"></a>
             </div>


### PR DESCRIPTION
Update landing page with these two changes
- remove Shopthru (it's a broken url now, RIP sweet prince 🫡)
- Update the copyright year from 2023 (🤔) to 2025