### PR TITLE
chore(security): SHA-pin all GitHub Actions (ENG-2401)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  # Keep SHA-pinned GitHub Actions moving forward. Dependabot rewrites the SHA
+  # and the trailing version comment together, so pins stay immutable and the
+  # workflows stay readable.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Install, build, and upload your site
-        uses: withastro/action@v0
+        uses: withastro/action@e3193ac80e18917ceaeb9f2d47019ad3b2c0416a # v0.3.2
         # with:
             # path: . # The root location of your Astro project inside the repository. (optional)
             # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@f27bcc15848fdcdcc02f01754eb838e44bcf389b # v1.2.9

--- a/.github/workflows/pinned-actions-check.yml
+++ b/.github/workflows/pinned-actions-check.yml
@@ -1,0 +1,44 @@
+name: Pinned Actions Check
+
+# Supply-chain guard (ENG-2401): every third-party `uses:` must reference an
+# immutable commit SHA, so a re-pointed tag on a compromised action cannot be
+# pulled into a run. Fails the PR when a workflow introduces a mutable ref.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pinned-actions-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pinact:
+    name: pinact run --check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Install pinact
+        env:
+          PINACT_VERSION: v4.1.1
+          PINACT_CHECKSUM: d1cffebe5704b74e2e5f8a864efb9f7e54768972dc686188c008033fb1797841
+        run: |
+          set -euo pipefail
+          curl -fsSL -o pinact.tar.gz \
+            "https://github.com/suzuki-shunsuke/pinact/releases/download/${PINACT_VERSION}/pinact_linux_amd64.tar.gz"
+          echo "${PINACT_CHECKSUM}  pinact.tar.gz" | sha256sum -c -
+          tar -xzf pinact.tar.gz pinact
+          sudo install -m 0755 pinact /usr/local/bin/pinact
+
+      - name: Verify every `uses:` is pinned to a full commit SHA
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pinact run --check


### PR DESCRIPTION
Mutable action tags are the last piece of exposure left over from the 2026-05-21 Shai-Hulud / Megalodon sweep: the org came back clean on IoCs, but every workflow still pulled its actions by tag. That is the exact vector the worm family uses: backdoor a trusted action, re-point the tag, and every consumer executes the payload on its next run. A commit SHA cannot be re-pointed.

This pins **3 `uses:` references across 1 workflow file** to full 40-char SHAs, keeping the original tag as a trailing comment so the files stay readable:

```yaml
        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
        uses: withastro/action@e3193ac80e18917ceaeb9f2d47019ad3b2c0416a # v0.3.2
```

The rewrite is mechanical (`pinact` v4.1.1) and behaviour-preserving: each action resolves to the exact commit its current tag points at today. No tag was bumped.

Two guards keep it pinned:

- **`.github/workflows/pinned-actions-check.yml`** runs `pinact run --check` on any PR touching `.github/workflows/**`, so a new mutable `uses:` fails the PR instead of landing. pinact itself is installed from a version-pinned release tarball verified against its SHA-256 checksum, so the guard doesn't reintroduce the problem it exists to prevent.
- **`.github/dependabot.yml`** enables weekly grouped `github-actions` updates. Dependabot rewrites the SHA and the version comment together, so pins move forward on a schedule rather than freezing at today's commits.

Part of an org-wide pass across the 18 `sibylline-advisory` repos that have workflows (402 references total).